### PR TITLE
Fix debug message for exposure time

### DIFF
--- a/prim_app/ui/control_panels/camera_control_panel.py
+++ b/prim_app/ui/control_panels/camera_control_panel.py
@@ -209,7 +209,7 @@ class CameraControlPanel(QWidget):
         try:
             node = self.grabber.device_property_map.find_float("ExposureTime")
             node.value = float(new_val)  # ✅ CORRECT WAY TO SET
-            log.debug(f"FPS set to {node.value}")
+            log.debug(f"ExposureTime set to {node.value} µs")
             self.exposure_slider.blockSignals(True)
             self.exposure_slider.setValue(int(float(new_val) * self._exp_scale))
             self.exposure_slider.blockSignals(False)


### PR DESCRIPTION
## Summary
- log the exposure time value correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684779944e288326b61ad6109ff8b61e