### PR TITLE
Remove extra IC4 cleanup calls

### DIFF
--- a/prim_app/main_window.py
+++ b/prim_app/main_window.py
@@ -1057,14 +1057,7 @@ class MainWindow(QMainWindow):
         except Exception:
             pass
 
-        # 5) Exit the IC4 library (if it’s still loaded)
-        try:
-            ic4.Library.exit()
-            log.info("DEBUG: IC4 library exited cleanly.")
-        except Exception:
-            pass
-
-        # 6) Process any remaining events, then call the base implementation
+        # 5) Process any remaining events, then call the base implementation
         QApplication.processEvents()
         log.info("All threads cleaned up. Proceeding with close.")
         super().closeEvent(event)

--- a/prim_app/threads/sdk_camera_thread.py
+++ b/prim_app/threads/sdk_camera_thread.py
@@ -232,15 +232,8 @@ class SDKCameraThread(QThread):
             self.error.emit(msg, code_str)
 
         finally:
-            try:
-                ic4.Library.exit()
-                log.info("SDKCameraThread: Library.exit() called.")
-                import imagingcontrol4.library as ic4lib
-
-                ic4lib.Library._core = None  # Prevent __del__ exceptions after exit
-
-            except Exception:
-                pass
+            # All cleanup is handled by MainWindow once threads have stopped.
+            pass
 
     def frames_queued(self, sink):
         """


### PR DESCRIPTION
## Summary
- remove internal `ic4.Library.exit()` calls that caused double cleanup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68477fa2ac588326b9276bc9702c65c3