### PR TITLE
Fix frame rate control when camera property lacks increment

### DIFF
--- a/prim_app/ui/control_panels/camera_control_panel.py
+++ b/prim_app/ui/control_panels/camera_control_panel.py
@@ -178,13 +178,10 @@ class CameraControlPanel(QWidget):
             log.warning(f"CameraControlPanel: Failed to init GainAuto: {e}")
 
         try:
-            fr_node = self.grabber.device_property_map.find_float(
-                "AcquisitionFrameRate"
+            # Use the generic helper so missing 'increment' does not disable the control
+            self._setup_float_control(
+                "AcquisitionFrameRate", self.framerate_spin, decimals=1
             )
-            self.framerate_spin.setRange(fr_node.minimum, fr_node.maximum)
-            self.framerate_spin.setSingleStep(fr_node.increment or 0.1)
-            self.framerate_spin.setValue(fr_node.value)  # ✅ CORRECT
-            self.framerate_spin.setEnabled(True)
         except Exception as e:
             log.warning(f"CameraControlPanel: Failed to init AcquisitionFrameRate: {e}")
 


### PR DESCRIPTION
## Summary
- handle cameras that don't report `increment` for AcquisitionFrameRate

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684783131ee4832699657e95a799d48c