### PR TITLE
Fix IC4 teardown order

### DIFF
--- a/prim_app/prim_app.py
+++ b/prim_app/prim_app.py
@@ -130,7 +130,6 @@ def main_app_entry():
 
     # Create the QApplication
     app = QApplication(sys.argv)
-    app.aboutToQuit.connect(ic4.Library.exit)
     apply_dark_theme(app)
 
     # Log what OpenGL/QSurfaceFormat we actually got
@@ -215,6 +214,11 @@ def main_app_entry():
 
     exit_code = app.exec_()
     log.info(f"Application event loop ended with exit code {exit_code}.")
+
+    try:
+        ic4.Library.exit()
+    except Exception:
+        pass
 
     sys.exit(exit_code)
 


### PR DESCRIPTION
## Summary
- avoid closing IC Imaging Control while Qt objects still exist
- explicitly shut down the IC4 library after the event loop ends

## Testing
- `pytest -q`
- `python -m pip check`
- `python -m compileall -q ./prim_app`


------
https://chatgpt.com/codex/tasks/task_e_684785aa40f883269186b1baaf3bb8a1