### PR TITLE
Implement OME-TIFF recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@
   - Hardware‑triggered camera acquisition: Arduino pulses `CamTrig` pin for each sample.  
   - RecordingManager captures exactly one camera frame per Arduino trigger, pulls the corresponding serial line (`frame_idx, elapsed_time_s, pressure`) and writes:  
     - **experiment_data.csv** (`frame_index, elapsed_time_s, pressure_value`)  
-    - **experiment_video.tiff** (multi‑page TIFF where each page’s ImageDescription tag contains `FrameIndex=…;Time_s=…;Pressure=…`)  
+    - **experiment_video.ome.tif** (OME‑TIFF with per‑frame metadata)
   - Output folder structure:  
     ```
     PRIM_ROOT/YYYY-MM-DD/FillN/
       ├ experiment_data.csv
-      └ experiment_video.tiff
+      └ experiment_video.ome.tif
     ```
 
 - **Simple UI Layout**  
@@ -116,7 +116,7 @@
 
 6. **Stop Recording**  
    - Click **Acquisition → Stop Recording** (or press **Ctrl+T**).  
-   - RecordingManager finalizes `experiment_data.csv` and `experiment_video.tiff`.  
+   - RecordingManager finalizes `experiment_data.csv` and `experiment_video.ome.tif`.
    - Status bar reads “Recording stopped and saved.”
 
 7. **Review Output**  
@@ -129,9 +129,8 @@
      3, 0.3000, 15.45
      …  
      ```  
-   - **experiment_video.tiff**: Multi‑page TIFF; each page’s ImageDescription tag contains:  
-     `FrameIndex=<n>;Time_s=<t>;Pressure=<p>`.  
-   - Use ImageJ/Fiji or Python (`tifffile`) to open and inspect frames with metadata.
+   - **experiment_video.ome.tif**: OME‑TIFF. Per‑frame timestamps and pressure values are stored in the `<Plane/>` elements.
+   - Use ImageJ/Fiji or Python (`tifffile`) to inspect frames and metadata.
 
 ---
 

--- a/prim_app/main_window.py
+++ b/prim_app/main_window.py
@@ -120,7 +120,7 @@ class MainWindow(QMainWindow):
         self._recorder_thread = QThread(self)
 
         dummy_output_dir = ""  # replace with a default or override later
-        self._recorder_worker = RecordingManager(dummy_output_dir)
+        self._recorder_worker = RecordingManager(dummy_output_dir, use_ome=True)
 
         # 3) Move the worker into the new thread:
         self._recorder_worker.moveToThread(self._recorder_thread)
@@ -861,7 +861,7 @@ class MainWindow(QMainWindow):
 
         # Create the recording thread + worker exactly as before:
         self._recorder_thread = QThread(self)
-        self._recorder_worker = RecordingManager(output_dir=outdir)
+        self._recorder_worker = RecordingManager(output_dir=outdir, use_ome=True)
         self._recorder_worker.moveToThread(self._recorder_thread)
 
         # 7) Wire up thread start → worker.start_recording()


### PR DESCRIPTION
## Summary
- support writing OME-TIFF from `RecordingManager`
- expose `use_ome` flag when constructing RecordingManager
- update video output filename to `.ome.tif`
- adjust main_window to enable OME writing
- update README for new OME-TIFF output

## Testing
- `python -m py_compile prim_app/recording_manager.py prim_app/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_684823fee9cc83268c110c4a2049abe0