### PR TITLE
Add button to zero PRIM device

### DIFF
--- a/prim_app/main_window.py
+++ b/prim_app/main_window.py
@@ -263,6 +263,7 @@ class MainWindow(QMainWindow):
 
         # TopControlPanel (center)
         self.top_ctrl = TopControlPanel(self)
+        self.top_ctrl.zero_requested.connect(self._on_zero_prim)
         top_row_lay.addWidget(self.top_ctrl, stretch=2)
 
         # PlotControlPanel (right)
@@ -649,6 +650,18 @@ class MainWindow(QMainWindow):
         ):
             self.pressure_plot_widget.clear_plot()
             self.statusBar().showMessage("Pressure plot data cleared.", 3000)
+
+    @pyqtSlot()
+    def _on_zero_prim(self):
+        """Send the zeroing command to the PRIM device."""
+        try:
+            if self._serial_thread and self._serial_thread.isRunning():
+                self._serial_thread.send_command("Z")
+                self.statusBar().showMessage("Zero command sent to PRIM", 2000)
+            else:
+                self.statusBar().showMessage("PRIM device not connected", 3000)
+        except Exception:
+            log.exception("Failed to send zero command to Arduino")
 
     def _set_initial_splitter_sizes(self):
         if self.bottom_split:

--- a/prim_app/ui/control_panels/top_control_panel.py
+++ b/prim_app/ui/control_panels/top_control_panel.py
@@ -6,6 +6,7 @@ from PyQt5.QtWidgets import (
     QHBoxLayout,
     QFormLayout,
     QLabel,
+    QPushButton,
 )
 from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
 
@@ -20,6 +21,7 @@ class TopControlPanel(QWidget):
     """
 
     parameter_changed = pyqtSignal(str, object)
+    zero_requested = pyqtSignal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -44,6 +46,11 @@ class TopControlPanel(QWidget):
         self.pres_lbl.setStyleSheet("font-size:12pt;font-weight:bold;")
         status_layout.addRow("Current Pressure:", self.pres_lbl)
 
+        self.zero_btn = QPushButton("Zero PRIM?")
+        self.zero_btn.setEnabled(False)
+        self.zero_btn.clicked.connect(self.zero_requested.emit)
+        status_layout.addRow(self.zero_btn)
+
         layout.addWidget(status_box, 1)
 
     def update_connection_status(self, text: str, connected: bool):
@@ -58,6 +65,7 @@ class TopControlPanel(QWidget):
         else:
             color = "#D6C832"
         self.conn_lbl.setStyleSheet(f"font-weight:bold;color:{color};")
+        self.zero_btn.setEnabled(connected)
 
     def update_prim_data(self, idx: int, t_dev: float, p_dev: float):
         """


### PR DESCRIPTION
## Summary
- add `Zero PRIM?` button to PRIM Device status panel
- connect button to send `Z` command to Arduino

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684848fe381883268e4d7f5dca9d7a01