### PR TITLE
Zero button clears plot

### DIFF
--- a/prim_app/main_window.py
+++ b/prim_app/main_window.py
@@ -653,13 +653,22 @@ class MainWindow(QMainWindow):
 
     @pyqtSlot()
     def _on_zero_prim(self):
-        """Send the zeroing command to the PRIM device."""
+        """Send the zeroing command to the PRIM device and clear the plot."""
         try:
+            # Clear the live pressure plot regardless of connection state
+            if self.pressure_plot_widget and hasattr(
+                self.pressure_plot_widget, "clear_plot"
+            ):
+                self.pressure_plot_widget.clear_plot()
+
             if self._serial_thread and self._serial_thread.isRunning():
+                # Send the zero command when the PRIM device is connected
                 self._serial_thread.send_command("Z")
-                self.statusBar().showMessage("Zero command sent to PRIM", 2000)
+                msg = "Zero command sent to PRIM and plot cleared."
             else:
-                self.statusBar().showMessage("PRIM device not connected", 3000)
+                msg = "PRIM device not connected; plot cleared."
+
+            self.statusBar().showMessage(msg, 3000)
         except Exception:
             log.exception("Failed to send zero command to Arduino")
 


### PR DESCRIPTION
## Summary
- clear pressure plot whenever the "Zero PRIM?" button is used
- update status message to indicate zeroing and clearing

## Testing
- `python -m py_compile prim_app/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68484a64a4f483268a85e7ff2e79ebb8