### PR TITLE
Refactor TIFF writing

### DIFF
--- a/tests/test_recording_manager.py
+++ b/tests/test_recording_manager.py
@@ -1,0 +1,16 @@
+import os
+import numpy as np
+import tifffile
+from prim_app.recording_manager import RecordingManager
+
+def test_recording_manager_simple(tmp_path, monkeypatch):
+    rm = RecordingManager(output_dir=tmp_path)
+    rm.start_recording()
+    monkeypatch.setattr(rm, "_qimage_to_numpy", lambda qimg: np.zeros((2, 2), dtype=np.uint8))
+    for i in range(3):
+        rm.append_pressure(i, i * 0.1, float(i))
+        rm.append_frame(None, None)
+    rm.stop_recording()
+    with tifffile.TiffFile(rm._tiff_path) as tf:
+        assert len(tf.pages) == 3
+


### PR DESCRIPTION
## Summary
- refactor `RecordingManager` to drop persistent `TiffWriter`
- write TIFF frames using `tifffile.imwrite`
- close only the CSV on stop
- add test for recording manager TIFF output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684857ef41288326ab3c0119dd2bcd7a