### PR TITLE
Add PyInstaller spec and packaging instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ wheels/
 .vscode/
 
 # PyInstaller
-*.spec
 dist/
 build/
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,15 @@
 
    - **experiment_video.tif**: Uncompressed grayscale TIFF.
 
-   - Use ImageJ/Fiji or Python (`tifffile`) to inspect frames and metadata.
+  - Use ImageJ/Fiji or Python (`tifffile`) to inspect frames and metadata.
+
+## Packaging
+
+Build a standalone executable with PyInstaller:
+
+```bash
+pyinstaller prim_app.spec
+```
 
 ---
 

--- a/prim_app.spec
+++ b/prim_app.spec
@@ -1,0 +1,53 @@
+# -*- mode: python ; coding: utf-8 -*-
+import os
+
+block_cipher = None
+
+project_root = os.path.abspath('.')
+
+a = Analysis(
+    ['prim_app/prim_app.py'],
+    pathex=[project_root],
+    binaries=[
+        # Add Imaging Control 4 DLLs here if needed, e.g. ('path/to/ic4.dll', '.')
+    ],
+    datas=[
+        ('prim_app/ui/icons/*', 'prim_app/ui/icons'),
+        ('prim_app/ui/style.qss', 'prim_app/ui'),
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='PRIMAcquisition',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    icon='prim_app/ui/icons/PRIM.ico',
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='PRIMAcquisition',
+)


### PR DESCRIPTION
## Summary
- allow tracking of `.spec` files by removing pattern from `.gitignore`
- create a `prim_app.spec` for PyInstaller packaging
- document packaging instructions in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68487373b4a083269ef7e0baa912f7cc